### PR TITLE
fixes Error associated with main.py string decode

### DIFF
--- a/dash/main.py
+++ b/dash/main.py
@@ -662,7 +662,7 @@ def generate_policy(n_clicks):
     for triple in iter(g):
         offer.add(triple)
     g.serialize(destination='dash/offer.ttl', format='turtle')
-    a = g.serialize(format='turtle').decode("utf-8")
+    a = g.serialize(format='turtle')
     g.remove((None, None, None))
     restrictions.remove((None, None, None))
     return a, '', []


### PR DESCRIPTION
RDFlib serialisation shouldn't need decoding

```
Traceback (most recent call last):
  File "/Users/harsh/code/duo-odrl-dpv/dash/main.py", line 665, in generate_policy
    a = g.serialize(format='turtle').decode("utf-8")
AttributeError: 'str' object has no attribute 'decode'
```